### PR TITLE
Stop crashes when attempting empty map updates

### DIFF
--- a/scripts/gvom.py
+++ b/scripts/gvom.py
@@ -105,7 +105,7 @@ class Gvom:
 
         point_count = pointcloud.shape[0]
         if point_count == 0:
-            print(f"[WARNING] Processing an empty pointcloud, nothing will happen.")
+            print(f"[WARNING] Processing an empty pointcloud, nothing will happen!")
             return
         pointcloud = cuda.to_device(pointcloud)
 
@@ -146,9 +146,9 @@ class Gvom:
         ###### Make index map so we only need to store data on non-empty voxels ######
         cell_count_cpu = cell_count.copy_to_host()[0]
         if cell_count_cpu == 0:
-            print(f"[WARNING] The pointcloud points don't overlap with any voxels. Nothing will happen!")
+            print(f"[WARNING] The pointcloud points don't overlap with any voxels, nothing will happen!")
             return
-        
+
         hit_count = cuda.device_array([cell_count_cpu], dtype=np.int32)
         total_count = cuda.device_array([cell_count_cpu], dtype=np.int32)
 
@@ -177,7 +177,7 @@ class Gvom:
     def combine_maps(self):
         """ Combines all maps in the buffer and processes the resultant map into 2D maps """
         if self.origin_buffer[self.last_buffer_index] is None:
-            print("ERROR: No data in buffer")
+            print("[WARNING] The map buffer is empty, nothing will happen!")
             return
 
         ###### Combine the lookup tables, calculate total number of occupied voxels ######

--- a/scripts/gvom.py
+++ b/scripts/gvom.py
@@ -341,7 +341,7 @@ class Gvom:
     def get_map_as_occupancy_grid(self):
         """ Returns the last combined map as a voxel occupancy grid """
         lookup_table = self.last_combined_index_map.copy_to_host()
-        lookup_table = lookup_table.reshape((self.xy_size, self.xy_size, self.z_size))
+        lookup_table = lookup_table.reshape((self.xy_size, self.xy_size, self.z_size), order='F')
         occupancy_grid = lookup_table >= 0
         return occupancy_grid
 

--- a/scripts/gvom.py
+++ b/scripts/gvom.py
@@ -1,9 +1,13 @@
 import numba
-from numba import vectorize, jit, cuda
+from numba import cuda, config
 import numpy as np
 import math
-import time
 import threading
+
+
+# Don't print warnings about GPU underutilization to keep the terminal clean
+config.CUDA_LOW_OCCUPANCY_WARNINGS = False
+
 
 class Gvom:
 


### PR DESCRIPTION
When an empty pointcloud, or a pointcloud which doesn't intersect with the map region is passed to the `process_pointcloud` method, the program crashed on the account of attempting to create 0 sized blocks of cuda kernels. Zero checks were added to print out a warning and end the method before this happens.
Also includes some small coding style improvements.